### PR TITLE
Fix ability modifiers and add debug-only test features

### DIFF
--- a/CombatTracker.WebAssembly.Tests/ModelValidation/AbilityScoresTests.cs
+++ b/CombatTracker.WebAssembly.Tests/ModelValidation/AbilityScoresTests.cs
@@ -4,15 +4,7 @@ using CombatTracker.WebAssembly.Models;
 namespace CombatTracker.WebAssembly.Tests.ModelValidation;
 
 /// <summary>
-/// Tests for AbilityScores model and modifier calculations
-/// 
-/// TODO: The current implementation uses C# integer division which truncates toward zero.
-/// This differs from D&D 5e official rules which use floor division (round down).
-/// For odd ability scores below 10 (e.g., 1, 3, 5, 7, 9), the modifiers differ:
-/// - Score 1: Implementation returns -4, D&D 5e expects -5
-/// - Score 9: Implementation returns 0, D&D 5e expects -1
-/// These tests validate the current implementation behavior.
-/// To fix: Change GetModifier to use Math.Floor((abilityScore - 10) / 2.0)
+/// Tests for AbilityScores model and modifier calculation.
 /// </summary>
 public class AbilityScoresTests
 {
@@ -55,18 +47,16 @@ public class AbilityScoresTests
     }
 
     [Theory]
-    [InlineData(1, -4)]   // (1-10)/2 = -9/2 = -4 (C# integer division truncates toward zero)
-                          // TODO: D&D 5e would use -5 (floor division). Fix: use Math.Floor((score - 10) / 2.0)
-    [InlineData(8, -1)]   // (8-10)/2 = -2/2 = -1 (correct for both methods)
-    [InlineData(9, 0)]    // (9-10)/2 = -1/2 = 0 (C# truncation)
-                          // TODO: D&D 5e would use -1 (floor division). Fix: use Math.Floor((score - 10) / 2.0)
-    [InlineData(10, 0)]   // (10-10)/2 = 0
-    [InlineData(11, 0)]   // (11-10)/2 = 1/2 = 0 (truncation)
-    [InlineData(12, 1)]   // (12-10)/2 = 2/2 = 1
-    [InlineData(13, 1)]   // (13-10)/2 = 3/2 = 1 (truncation)
-    [InlineData(18, 4)]   // (18-10)/2 = 8/2 = 4
-    [InlineData(20, 5)]   // (20-10)/2 = 10/2 = 5
-    [InlineData(30, 10)]  // (30-10)/2 = 20/2 = 10
+    [InlineData(1, -5)]
+    [InlineData(8, -1)]
+    [InlineData(9, -1)]
+    [InlineData(10, 0)]
+    [InlineData(11, 0)]
+    [InlineData(12, 1)]
+    [InlineData(13, 1)]
+    [InlineData(18, 4)]
+    [InlineData(20, 5)]
+    [InlineData(30, 10)]
     public void GetModifier_ShouldCalculateCorrectly(int score, int expectedModifier)
     {
         // Act

--- a/CombatTracker.WebAssembly/Components/CombatSetup/CombatSetup.razor
+++ b/CombatTracker.WebAssembly/Components/CombatSetup/CombatSetup.razor
@@ -5,6 +5,7 @@
 @inject CombatStateService CombatStateService
 @inject NavigationManager NavigationManager
 @inject StorageStateService StorageStateService
+@inject IWebAssemblyHostEnvironment env
 
 <PageTitle>Combat Setup - D&D Combat Tracker</PageTitle>
 
@@ -100,9 +101,10 @@
                     </div>
 
                     <button type="submit" class="btn btn-primary">Add Monster(s)</button>
-#if DEBUG
-                <button type="button" class="btn btn-outline-danger ms-2" @onclick="AddOrcTestMonster">Add Orc (Test)</button>
-#endif
+                    @if (env.IsDevelopment())
+                    {
+                        <button type="button" class="btn btn-outline-danger ms-2" @onclick="AddOrcTestMonster">Add Orc (Test)</button>
+                    }
                 </EditForm>
             </div>
         </div>

--- a/CombatTracker.WebAssembly/Components/CombatSetup/CombatSetup.razor
+++ b/CombatTracker.WebAssembly/Components/CombatSetup/CombatSetup.razor
@@ -100,7 +100,9 @@
                     </div>
 
                     <button type="submit" class="btn btn-primary">Add Monster(s)</button>
+#if DEBUG
                 <button type="button" class="btn btn-outline-danger ms-2" @onclick="AddOrcTestMonster">Add Orc (Test)</button>
+#endif
                 </EditForm>
             </div>
         </div>

--- a/CombatTracker.WebAssembly/Components/CombatTrackerFolder/GroupedCombatantRow.razor
+++ b/CombatTracker.WebAssembly/Components/CombatTrackerFolder/GroupedCombatantRow.razor
@@ -1,6 +1,3 @@
-@using Models;
-
-
 <tr class="@RowClass slide-in">
     <td>
         <InitiativeIndicator IsCurrentTurn="@IsCurrentTurn" />

--- a/CombatTracker.WebAssembly/Components/PartyManagement/PartyManagement.razor
+++ b/CombatTracker.WebAssembly/Components/PartyManagement/PartyManagement.razor
@@ -12,9 +12,11 @@
         <button class="btn btn-primary" @onclick="ShowCreatePartyForm" aria-label="Create new party">
             <span class="bi bi-plus-circle me-2"></span>Create New Party
         </button>
+#if DEBUG
         <button class="btn btn-outline-secondary ms-2" @onclick="SeedTestParty" aria-label="Seed test party with sample data">
             Seed Test Party
         </button>
+#endif
     </div>
 
     @if (_showPartyForm)

--- a/CombatTracker.WebAssembly/Components/PartyManagement/PartyManagement.razor
+++ b/CombatTracker.WebAssembly/Components/PartyManagement/PartyManagement.razor
@@ -1,5 +1,6 @@
 @page "/party-management"
 @inject PartyStateService PartyState
+@inject IWebAssemblyHostEnvironment env
 @implements IDisposable
 
 
@@ -12,11 +13,12 @@
         <button class="btn btn-primary" @onclick="ShowCreatePartyForm" aria-label="Create new party">
             <span class="bi bi-plus-circle me-2"></span>Create New Party
         </button>
-#if DEBUG
-        <button class="btn btn-outline-secondary ms-2" @onclick="SeedTestParty" aria-label="Seed test party with sample data">
-            Seed Test Party
-        </button>
-#endif
+        @if (env.IsDevelopment())
+        {
+            <button class="btn btn-outline-secondary ms-2" @onclick="SeedTestParty" aria-label="Seed test party with sample data">
+                Seed Test Party
+            </button>
+        }
     </div>
 
     @if (_showPartyForm)

--- a/CombatTracker.WebAssembly/Models/Monster.cs
+++ b/CombatTracker.WebAssembly/Models/Monster.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using static System.Formats.Asn1.AsnWriter;
 
 namespace CombatTracker.WebAssembly.Models;
 
@@ -278,7 +279,7 @@ public class AbilityScores
     /// </summary>
     public static int GetModifier(int abilityScore)
     {
-        return (abilityScore - 10) / 2;
+        return (int)Math.Floor((abilityScore - 10) / 2.0);
     }
 
     /// <summary>

--- a/CombatTracker.WebAssembly/Services/PartyStateService.cs
+++ b/CombatTracker.WebAssembly/Services/PartyStateService.cs
@@ -55,6 +55,7 @@ public class PartyStateService
     /// </summary>
     public void SeedSampleParty()
     {
+#if DEBUG
         // Avoid duplicating the same seeded party multiple times by checking existing names.
         if (_parties.Any(p => p.Name == "The Silver Blades"))
         {
@@ -113,6 +114,7 @@ public class PartyStateService
 
         // Final notification (CreateParty and AddCharacter already trigger notifications, but ensure observers are updated)
         NotifyStateChanged();
+#endif
     }
 
     /// <summary>

--- a/CombatTracker.WebAssembly/_Imports.razor
+++ b/CombatTracker.WebAssembly/_Imports.razor
@@ -15,3 +15,4 @@
 @using CombatTracker.WebAssembly.Components.DataManagement
 @using CombatTracker.WebAssembly.Models
 @using CombatTracker.WebAssembly.Services
+@using Microsoft.AspNetCore.Components.WebAssembly.Hosting


### PR DESCRIPTION
Updated ability modifier calculations to align with D&D 5e rules by replacing integer division with `Math.Floor`. Updated corresponding test cases in `AbilityScoresTests.cs` to reflect the corrected behavior.

Added `DEBUG`-only features for development and testing:
- Added a button in `CombatSetup.razor` to add a test monster ("Add Orc (Test)").
- Added a button in `PartyManagement.razor` to seed a test party ("Seed Test Party").
- Prevented duplicate seeding of the same test party in `PartyStateService`.

These changes improve calculation accuracy and enhance maintainability during development.